### PR TITLE
BUG: Don't link function parameter names to variables from outer scop…

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -1181,7 +1181,9 @@ class Function(Doc):
                 s = s.replace(' ', '\N{NBSP}')  # prevent improper line breaking
 
                 if link:
-                    s = re.sub(r'[\w\.]+', _linkify, s)
+                    annotation = inspect.formatannotation(p.annotation)
+                    linked_annotation = re.sub(r'[\w\.]+', _linkify, annotation)
+                    s = linked_annotation.join(s.rsplit(annotation, 1))  # "rreplace" once
 
             params.append(s)
 

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -695,6 +695,11 @@ class ApiTest(unittest.TestCase):
                          ['a:\N{NBSP}int', '*b',
                           "c:\N{NBSP}List[<a href=\"#pdoc.Doc\">Doc</a>]\N{NBSP}=\N{NBSP}[]"])
 
+        # shadowed name
+        def f(pdoc: int): pass
+        func = pdoc.Function('f', mod, f)
+        self.assertEqual(func.params(annotate=True, link=link), ['pdoc:\N{NBSP}int'])
+
         def bug130_str_annotation(a: "str"):
             return
 


### PR DESCRIPTION
…e (#153)

* BUG: Fix function parameters that shadow names from outer scope

* another solution

* replace from the right, just in case

Co-authored-by: kernc <kerncece@gmail.com>